### PR TITLE
Make plugin compatible with Weatherwax

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base    edittable
 author  Adrian Lang
 email   lang@cosmocode.de
-date    2010-03-22
+date    2012-07-02
 name    edittable plugin
 desc    Provide a custom editor for tables
 url     http://www.dokuwiki.org/plugin:edittable

--- a/script/tableeditor.js
+++ b/script/tableeditor.js
@@ -13,8 +13,8 @@
  * @author Adrian Lang <lang@cosmocode.de>
  */
 
-addInitEvent(function () {
-    var table = getElementsByClass('edit', document, 'table')[0];
+jQuery(function () {
+    var table = jQuery('table.edit')[0];
     if (!table) {
         // There is no table editor.
         return;


### PR DESCRIPTION
Quick fix to remove incompatibilities caused by removal of 'compatibility.js' in weatherwax. 

Note, this version of the plugin will not work with DokuWiki versions before Angua.
