### PR TITLE
Display DokuWiki's line breaks (\\) as real line breaks (\n).

### DIFF
--- a/script/editor.js
+++ b/script/editor.js
@@ -223,8 +223,21 @@ jQuery(function () {
                 }
             }
 
-            // Store data and meta back in the form
-            $datafield.val(JSON.stringify(data));
+            // Clone data object
+            // Since we can't use real line breaks (\n) inside table cells, this object is used to store all cell values with DokuWiki's line breaks (\\) instead of actual ones.
+            var dataLBFixed = jQuery.extend(true, {}, data);
+
+            // In dataLBFixed, replace all actual line breaks with DokuWiki line breaks
+            // In data, replace all DokuWiki line breaks with actual ones so the editor displays line breaks properly
+            for (row = 0; row < data.length; row++) {
+                for (col = 0; col < data[0].length; col++) {
+                    dataLBFixed[row][col] = data[row][col].replace(/(\r\n|\n|\r)/g,"\\\\ ");
+                    data[row][col]        = data[row][col].replace(/\\\\\s/g,"\n");
+                }
+            }
+
+            // Store dataFixed and meta back in the form
+            $datafield.val(JSON.stringify(dataLBFixed));
             $metafield.val(JSON.stringify(meta));
         },
 


### PR DESCRIPTION
I've been using this plugin for a while now and it made editing tables indeed a whole lot easier.
However, I often had to create and edit tables with line breaks inside of cells which quickly started to look confusing because I couldn't just use Alt+Enter or Strg+Enter (which both did insert a real line break but broke the table syntax since you can't use real line breaks in table cells). Instead, I had to use \\\\ .
Recently I had to port very complex table to DokuWiki and so I decided to modify this plugin to make creating/editing such tables easier.

So this commit does the following:
- DokuWiki line breaks (\\\\ ) are displayed as real line breaks (\n)
- If you insert a DokuWiki line break, it is converted to a real line break when you leave the cell
- If you use Alt+Enter / Strg+Enter to insert a real line break, the table syntax doesn't break anymore since upon saving all line breaks are converted to DokuWiki's line breaks

If you need a demo, just let me know and I'll set up a DokuWiki with the modified plugin.