### PR TITLE
linebreak handling

### DIFF
--- a/renderer/json.php
+++ b/renderer/json.php
@@ -119,7 +119,7 @@ class renderer_plugin_edittable_json extends renderer_plugin_edittable_inverse {
         $row = $this->current_row;
         $col = $this->current_col;
 
-        $this->tdata[$row][$col] = trim(str_replace("\n", ' ', $this->doc)); // no newlines in table cells!
+        $this->tdata[$row][$col] = trim($this->doc); //trim(str_replace("\n", ' ', $this->doc)); // no newlines in table cells!
         $this->tmeta[$row][$col] = $this->tmetacell; // as remembered in the open call
 
         // now fill up missing span cells

--- a/script/jquery.handsontable.full.js
+++ b/script/jquery.handsontable.full.js
@@ -4792,8 +4792,11 @@ Handsontable.SelectionPoint.prototype.arr = function (arr) {
         var isMultipleSelection = !(selected[0] === selected[2] && selected[1] === selected[3]);
         if ((ctrlDown && !isMultipleSelection) || event.altKey) { //if ctrl+enter or alt+enter, add new line
           if(that.isOpened()){
-            that.setValue(that.getValue() + '\n');
-            that.focus();
+            //that.setValue(that.getValue() + '\n');
+            var caretPosition = that.wtDom.getCaretPosition(that.TEXTAREA);
+            that.setValue(that.getValue().substr(0, caretPosition) + '\n' + that.getValue().substr(caretPosition));
+            that.wtDom.setCaretPosition(that.TEXTAREA, caretPosition + 1);
+            //that.focus();
           } else {
             that.beginEditing(that.originalValue + '\n')
           }


### PR DESCRIPTION
1.)
on handsone editing mode, linebreaks in tablecells are removed. this breaks syntax especially when using `<code></code>` within tables where linebreaks are allowed. 
```
|program one| <code>
echo "Hello World";
echo "Hello World";
</code> |
| | |
```

2.)
handsome has a bug when pressing ctrl+enter to insert linebreak. it actually inserts a linebreak at the end of the cell and not at current place see handsontable/handsontable#1139