### PR TITLE
Remove Background image introduced by template css collision

### DIFF
--- a/less/editor.less
+++ b/less/editor.less
@@ -15,6 +15,7 @@
         td.header {
             font-weight: bold;
             background-color: @ini_background_alt;
+            background-image: none;
         }
 
     }


### PR DESCRIPTION
In some templates there is a background image defined for `div.dokuwiki .header`. However this image then also appears when editing a table with edittable, which is usually not the desired behavior.
Hence we should set the background-image for `#edittable__editor table td.header` explicitly to `none`.