### PR TITLE
Add config for default column width

### DIFF
--- a/action/jsinfo.php
+++ b/action/jsinfo.php
@@ -1,0 +1,24 @@
+<?php
+
+if(!defined('DOKU_INC')) die();
+
+/**
+ * handles the data that has to be written into jsinfo
+ *
+ * like displaying the editor and adding custom edit buttons
+ */
+class action_plugin_edittable_jsinfo extends DokuWiki_Action_Plugin {
+
+    /**
+     * Register its handlers with the DokuWiki's event controller
+     */
+    function register(Doku_Event_Handler $controller) {
+        // register custom edit buttons
+        $controller->register_hook('DOKUWIKI_STARTED', 'BEFORE', $this, 'fill_jsinfo');
+    }
+
+    function fill_jsinfo() {
+        global $JSINFO;
+        $JSINFO['plugins']['edittable']['default columnwidth'] = $this->getConf('default colwidth');
+    }
+}

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,0 +1,3 @@
+<?php
+
+$conf['default colwidth'] = '';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,0 +1,3 @@
+<?php
+
+$meta['default colwidth'] = array('numericopt', '_min' => 50);

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,0 +1,3 @@
+<?php
+
+$lang['default colwidth'] = 'Width of table columns. Leave empty to base width on content';

--- a/script/editor.js
+++ b/script/editor.js
@@ -551,6 +551,10 @@ edittable.loadEditor = function () {
         }
     };
 
+    if (window.JSINFO.plugins.edittable['default columnwidth']) {
+        handsontable_config.colWidths = window.JSINFO.plugins.edittable['default columnwidth'];
+    }
+
 
     for (var plugin in edittable_plugins) {
         if (edittable_plugins.hasOwnProperty(plugin)) {


### PR DESCRIPTION
Currently the default width of a cell is wide enough to support its
entire content. Add the config option to specify a default width for all
columns. This may make sense since for cells with very wide content the
cell may become wider than the screen.

ABY-67