### PR TITLE
Remove @charset from less to fix safari bug

### DIFF
--- a/less/handsontable.full.less
+++ b/less/handsontable.full.less
@@ -1231,7 +1231,14 @@ thead .htCollapseButton:after {
   position: absolute;
   left: 4px;
 }
-@charset "UTF-8";
+/**
+* DOKUWIKI: Removing this erroneous charset notation here, since it caused a bug in safari
+* This may already be fixed upstream, so this is only temporary until we update handsontable again
+* see https://github.com/cosmocode/edittable/issues/91
+*
+* @charset "UTF-8";
+*/
+
 
 /*!
  * Pikaday


### PR DESCRIPTION
This charset caused the background icon of DokuWiki messages in safari to be displayed multiple times.

I assume it is already fixed upstream, so this is only temporary until we update handsontable again.

This fixes #91, SPR-891