### PR TITLE
Fix linkwizard

### DIFF
--- a/script/handsontable.full.js
+++ b/script/handsontable.full.js
@@ -17379,7 +17379,10 @@ function TableView(instance) {
     if (that.settings.outsideClickDeselects) {
       instance.deselectCell();
     } else {
-      instance.destroyEditor();
+      // COSMOCODE
+      if(!jQuery('#link__wiz').is(':visible')) {
+        instance.destroyEditor();
+      }
     }
   });
   this.eventManager.addEventListener(table, 'selectstart', function(event) {


### PR DESCRIPTION
This makes the link-wizard usable again.

It changes the handsontable.full.js since this seems to be the only way to get the full functionality of the link-wizard. (As suggested by @lisps)
However, the trade-off is that we may have to redo this when we update the handsontable library.
An alternative approach, which does not change handsontable.full.js but aborts the cell-edit-session, is implemented in 12251b3e6cb62bdb1b8f4ccb43169c6cfaf7eae7

fixes #32