### PR TITLE
explicitly define the text color

### DIFF
--- a/less/editor.less
+++ b/less/editor.less
@@ -20,6 +20,7 @@
 
         td.header {
             font-weight: bold;
+            color: @ini_text_alt;
             background-color: @ini_background_alt;
             background-image: none;
         }
@@ -40,4 +41,9 @@ div.picker {
 
 #link__wiz {
     z-index: 103; // the highest relevant z-index of edittable elements seems to be 103
+}
+
+// add color property
+.handsontable td {
+    color: #222;
 }


### PR DESCRIPTION
When I used the editable plugin with adoradark template, edit table mode show me the white background and nearly white text color which as shown in the picture below.
![2019-10-16_before1](https://user-images.githubusercontent.com/3655283/66928314-25092000-f06c-11e9-9ff2-f23c7b10e4c5.png)

To avoid this situation, I add the definition of the text color explicitly in less/editor.less. It works like that.
![2019-10-16_after](https://user-images.githubusercontent.com/3655283/66927881-8aa8dc80-f06b-11e9-9607-e83282b095b0.png).
