### PR TITLE
Fix external links without a title in Hogfather

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,22 @@
 language: php
 php:
+  - "nightly"
+  - "7.4"
+  - "7.3"
+  - "7.2"
   - "7.1"
   - "7.0"
   - "5.6"
 env:
   - DOKUWIKI=master
+matrix:
+  allow_failures:
+    - php: "nightly"
 before_install:
   - wget https://raw.github.com/splitbrain/dokuwiki-travis/master/travis.sh
   - npm install
 install: sh travis.sh
 script:
-  - cd _test && phpunit --stderr --group plugin_edittable
+  - cd _test && ./phpunit.phar --stderr --group plugin_edittable
   - cd ../lib/plugins/edittable && grunt
   - grunt eslint

--- a/renderer/inverse.php
+++ b/renderer/inverse.php
@@ -25,6 +25,8 @@ class renderer_plugin_edittable_inverse extends Doku_Renderer {
     private $_table = array();
     private $_liststack = array();
     private $quotelvl = 0;
+    private $extlinkparser = null;
+    protected $extlinkPatterns = [];
 
     function getFormat() {
         return 'wiki';
@@ -249,7 +251,7 @@ class renderer_plugin_edittable_inverse extends Doku_Renderer {
         $this->not_block();
         if(strpos($text, '%%') !== false) {
             $this->doc .= "<nowiki>$text</nowiki>";
-        } elseif($text{0} == "\n") {
+        } elseif($text[0] == "\n") {
             $this->doc .= "<nowiki>$text</nowiki>";
         } else {
             $this->doc .= "%%$text%%";
@@ -321,7 +323,7 @@ class renderer_plugin_edittable_inverse extends Doku_Renderer {
         }
         $this->doc .= ">";
         $this->doc .= $text;
-        if($text{0} == "\n") $this->doc .= "\n";
+        if($text[0] == "\n") $this->doc .= "\n";
         $this->doc .= "</$type>";
     }
 
@@ -407,19 +409,62 @@ class renderer_plugin_edittable_inverse extends Doku_Renderer {
     function externallink($url, $name = null) {
         $this->not_block();
 
+        /*
+         * When $name is null it might have been a match of an URL that was in the text without
+         * any link syntax. These are recognized by a bunch of patterns in Doku_Parser_Mode_externallink.
+         * We simply reuse these patterns here. However, since we don't parse the pattern through the Lexer,
+         * no escaping is done on the patterns - this means we need a non-conflicting delimiter. I decided for
+         * a single tick >>'<< which seems to work. Since the patterns contain wordboundaries they are matched
+         * against the URL surrounded by spaces.
+         */
         if($name === null) {
-            // FIXME there is no way of knowing if we are inside link syntax or not
-            $this->doc .= $url;
-            return;
+            // get the patterns from the parser if available, otherwise use a duplicate
+            if(is_null($this->extlinkparser)) {
+                if (
+                    class_exists('\dokuwiki\Parsing\ParserMode\Externallink') &&
+                    method_exists('\dokuwiki\Parsing\ParserMode\Externallink', 'getPatterns')
+                ) {
+                    $this->extlinkparser = new \dokuwiki\Parsing\ParserMode\Externallink();
+                    $this->extlinkparser->preConnect();
+                    $this->extlinkPatterns = $this->extlinkparser->getPatterns();
+                } else {
+                    $ltrs = '\w';
+                    $gunk = '/\#~:.?+=&%@!\-\[\]';
+                    $punc = '.:?\-;,';
+                    $host = $ltrs . $punc;
+                    $any  = $ltrs . $gunk . $punc;
+
+                    $schemes = getSchemes();
+                    foreach ($schemes as $scheme) {
+                        $this->extlinkPatterns[] = '\b(?i)'.$scheme.'(?-i)://['.$any.']+?(?=['.$punc.']*[^'.$any.'])';
+                    }
+
+                    $this->extlinkPatterns[] = '(?<=\s)(?i)www?(?-i)\.['.$host.']+?\.['.$host.']+?['.$any.']+?(?=['.$punc.']*[^'.$any.'])';
+                    $this->extlinkPatterns[] = '(?<=\s)(?i)ftp?(?-i)\.['.$host.']+?\.['.$host.']+?['.$any.']+?(?=['.$punc.']*[^'.$any.'])';
+                }
+            }
+
+            // check if URL matches pattern
+            foreach($this->extlinkPatterns as $pattern) {
+                if(preg_match("'$pattern'", " $url ")) {
+                    $this->doc .= $url; // gotcha!
+                    return;
+                }
+            }
         }
 
+        // still here?
         if($url === "http://$name" || $url === "ftp://$name") {
             // special case - www.* or ftp.* matching
             $this->doc .= $name;
         } else {
+            // link syntax! definitively link syntax
             $this->doc .= "[[$url";
-            $this->doc .= '|';
-            $this->_echoLinkTitle($name);
+            if(!is_null($name)) {
+                // we do have a name!
+                $this->doc .= '|';
+                $this->_echoLinkTitle($name);
+            }
             $this->doc .= ']]';
         }
     }

--- a/renderer/inverse.php
+++ b/renderer/inverse.php
@@ -25,7 +25,6 @@ class renderer_plugin_edittable_inverse extends Doku_Renderer {
     private $_table = array();
     private $_liststack = array();
     private $quotelvl = 0;
-    private $_extlinkparser = null;
 
     function getFormat() {
         return 'wiki';
@@ -408,42 +407,19 @@ class renderer_plugin_edittable_inverse extends Doku_Renderer {
     function externallink($url, $name = null) {
         $this->not_block();
 
-        /*
-         * When $name is null it might have been a match of an URL that was in the text without
-         * any link syntax. These are recognized by a bunch of patterns in Doku_Parser_Mode_externallink.
-         * We simply reuse these patterns here. However, since we don't parse the pattern through the Lexer,
-         * no escaping is done on the patterns - this means we need a non-conflicting delimiter. I decided for
-         * a single tick >>'<< which seems to work. Since the patterns contain wordboundaries they are matched
-         * against the URL surrounded by spaces.
-         */
         if($name === null) {
-            // get the patterns from the parser
-            if(is_null($this->_extlinkparser)) {
-                $this->_extlinkparser = new Doku_Parser_Mode_externallink();
-                $this->_extlinkparser->preConnect();
-            }
-
-            // check if URL matches pattern
-            foreach($this->_extlinkparser->patterns as $pattern) {
-                if(preg_match("'$pattern'", " $url ")) {
-                    $this->doc .= $url; // gotcha!
-                    return;
-                }
-            }
+            // FIXME there is no way of knowing if we are inside link syntax or not
+            $this->doc .= $url;
+            return;
         }
 
-        // still here?
         if($url === "http://$name" || $url === "ftp://$name") {
             // special case - www.* or ftp.* matching
             $this->doc .= $name;
         } else {
-            // link syntax! definitively link syntax
             $this->doc .= "[[$url";
-            if(!is_null($name)) {
-                // we do have a name!
-                $this->doc .= '|';
-                $this->_echoLinkTitle($name);
-            }
+            $this->doc .= '|';
+            $this->_echoLinkTitle($name);
             $this->doc .= ']]';
         }
     }


### PR DESCRIPTION
This commit breaks a test because we can no longer detect whether the link is surrounded by link syntax. An alternative would be to actually duplicate pattern detection as in #190