### PR TITLE
support new EDIT_FORM_ADDTEXTAREA event

### DIFF
--- a/_test/renderer_plugin_edittable_json.test.php
+++ b/_test/renderer_plugin_edittable_json.test.php
@@ -52,10 +52,9 @@ EOF;
         );
 
         $renderer = $this->render($input);
-        $json = new JSON(JSON_LOOSE_TYPE);
 
-        $this->assertEquals($data, $json->decode($renderer->getDataJSON()));
-        $this->assertEquals($meta, $json->decode($renderer->getMetaJSON()));
+        $this->assertEquals($data, json_decode($renderer->getDataJSON(), true));
+        $this->assertEquals($meta, json_decode($renderer->getMetaJSON(), true));
     }
 
 

--- a/action/editor.php
+++ b/action/editor.php
@@ -14,8 +14,8 @@ if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC.'lib/plugins/');
  *
  * like displaying the editor and adding custom edit buttons
  */
-class action_plugin_edittable_editor extends DokuWiki_Action_Plugin {
-
+class action_plugin_edittable_editor extends DokuWiki_Action_Plugin
+{
     /**
      * Register its handlers with the DokuWiki's event controller
      */
@@ -40,10 +40,10 @@ class action_plugin_edittable_editor extends DokuWiki_Action_Plugin {
      *
      * @param Doku_Event $event
      */
-    function secedit_button(Doku_Event $event) {
-        if($event->data['target'] !== 'table') {
-            return;
-        }
+    public function secedit_button(Doku_Event $event)
+    {
+        if ($event->data['target'] !== 'table') return;
+
         $event->data['name'] = $this->getLang('secedit_name');
     }
 
@@ -151,12 +151,12 @@ class action_plugin_edittable_editor extends DokuWiki_Action_Plugin {
         $colmax = $cols ? array_fill(0, $cols, 0) : array();
 
         // find maximum column widths
-        for($row = 0; $row < $rows; $row++) {
-            for($col = 0; $col < $cols; $col++) {
+        for ($row = 0; $row < $rows; $row++) {
+            for ($col = 0; $col < $cols; $col++) {
                 $len = dokuwiki\Utf8\PhpString::strlen($data[$row][$col]);
 
                 // alignment adds padding
-                if($meta[$row][$col]['align'] == 'center') {
+                if ($meta[$row][$col]['align'] == 'center') {
                     $len += 4;
                 } else {
                     $len += 3;
@@ -165,19 +165,19 @@ class action_plugin_edittable_editor extends DokuWiki_Action_Plugin {
                 // remember lenght
                 $meta[$row][$col]['length'] = $len;
 
-                if($len > $colmax[$col]) $colmax[$col] = $len;
+                if ($len > $colmax[$col]) $colmax[$col] = $len;
             }
         }
 
         $last = '|'; // used to close the last cell
-        for($row = 0; $row < $rows; $row++) {
-            for($col = 0; $col < $cols; $col++) {
+        for ($row = 0; $row < $rows; $row++) {
+            for ($col = 0; $col < $cols; $col++) {
 
                 // minimum padding according to alignment
-                if($meta[$row][$col]['align'] == 'center') {
+                if ($meta[$row][$col]['align'] == 'center') {
                     $lpad = 2;
                     $rpad = 2;
-                } elseif($meta[$row][$col]['align'] == 'right') {
+                } elseif ($meta[$row][$col]['align'] == 'right') {
                     $lpad = 2;
                     $rpad = 1;
                 } else {
@@ -189,13 +189,13 @@ class action_plugin_edittable_editor extends DokuWiki_Action_Plugin {
                 $target = $colmax[$col];
 
                 // colspanned columns span all the cells
-                for($i = 1; $i < $meta[$row][$col]['colspan']; $i++) {
+                for ($i = 1; $i < $meta[$row][$col]['colspan']; $i++) {
                     $target += $colmax[$col + $i];
                 }
 
                 // copy colspans to rowspans below if any
-                if($meta[$row][$col]['colspan'] > 1){
-                    for($i = 1; $i < $meta[$row][$col]['rowspan']; $i++) {
+                if ($meta[$row][$col]['colspan'] > 1){
+                    for ($i = 1; $i < $meta[$row][$col]['rowspan']; $i++) {
                         $meta[$row + $i][$col]['colspan'] = $meta[$row][$col]['colspan'];
                     }
                 }
@@ -205,7 +205,7 @@ class action_plugin_edittable_editor extends DokuWiki_Action_Plugin {
                 $addpad = $target - $length;
 
                 // decide which side needs padding
-                if($meta[$row][$col]['align'] == 'right') {
+                if ($meta[$row][$col]['align'] == 'right') {
                     $lpad += $addpad;
                 } else {
                     $rpad += $addpad;
@@ -213,7 +213,7 @@ class action_plugin_edittable_editor extends DokuWiki_Action_Plugin {
 
                 // add the padding
                 $cdata = $data[$row][$col];
-                if(!$meta[$row][$col]['hide'] || $cdata) {
+                if (!$meta[$row][$col]['hide'] || $cdata) {
                     $cdata = str_pad('', $lpad).$cdata.str_pad('', $rpad);
                 }
 

--- a/action/editor.php
+++ b/action/editor.php
@@ -6,8 +6,8 @@
  * @author Andreas Gohr <gohr@cosmocode.de>
  */
 
-if(!defined('DOKU_INC')) die();
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC.'lib/plugins/');
+use dokuwiki\Form\Form;
+use dokuwiki\Utf8;
 
 /**
  * handles all the editor related things
@@ -83,7 +83,7 @@ class action_plugin_edittable_editor extends DokuWiki_Action_Plugin
         /** @var Doku_Form $form */
         $form =& $event->data['form'];
 
-        if (is_a($form, dokuwiki\Form\Form::class)) { // $event->name is EDIT_FORM_ADDTEXTAREA
+        if (is_a($form, Form::class)) { // $event->name is EDIT_FORM_ADDTEXTAREA
             // data for handsontable
             $form->setHiddenField('edittable_data', $Renderer->getDataJSON());
             $form->setHiddenField('edittable_meta', $Renderer->getMetaJSON());
@@ -143,7 +143,8 @@ class action_plugin_edittable_editor extends DokuWiki_Action_Plugin
      * @param array $meta meta data for each cell
      * @return string
      */
-    public function build_table($data, $meta) {
+    public function build_table($data, $meta)
+    {
         $table = '';
         $rows  = count($data);
         $cols  = $rows ? count($data[0]) : 0;
@@ -153,7 +154,7 @@ class action_plugin_edittable_editor extends DokuWiki_Action_Plugin
         // find maximum column widths
         for ($row = 0; $row < $rows; $row++) {
             for ($col = 0; $col < $cols; $col++) {
-                $len = dokuwiki\Utf8\PhpString::strlen($data[$row][$col]);
+                $len = Utf8\PhpString::strlen($data[$row][$col]);
 
                 // alignment adds padding
                 if ($meta[$row][$col]['align'] == 'center') {

--- a/action/editor.php
+++ b/action/editor.php
@@ -153,7 +153,7 @@ class action_plugin_edittable_editor extends DokuWiki_Action_Plugin {
         // find maximum column widths
         for($row = 0; $row < $rows; $row++) {
             for($col = 0; $col < $cols; $col++) {
-                $len = utf8_strlen($data[$row][$col]);
+                $len = dokuwiki\Utf8\PhpString::strlen($data[$row][$col]);
 
                 // alignment adds padding
                 if($meta[$row][$col]['align'] == 'center') {

--- a/action/editor.php
+++ b/action/editor.php
@@ -154,7 +154,7 @@ class action_plugin_edittable_editor extends DokuWiki_Action_Plugin
         // find maximum column widths
         for ($row = 0; $row < $rows; $row++) {
             for ($col = 0; $col < $cols; $col++) {
-                $len = Utf8\PhpString::strlen($data[$row][$col]);
+                $len = $this->strWidth($data[$row][$col]);
 
                 // alignment adds padding
                 if ($meta[$row][$col]['align'] == 'center') {
@@ -195,7 +195,7 @@ class action_plugin_edittable_editor extends DokuWiki_Action_Plugin
                 }
 
                 // copy colspans to rowspans below if any
-                if ($meta[$row][$col]['colspan'] > 1){
+                if ($meta[$row][$col]['colspan'] > 1) {
                     for ($i = 1; $i < $meta[$row][$col]['rowspan']; $i++) {
                         $meta[$row + $i][$col]['colspan'] = $meta[$row][$col]['colspan'];
                     }
@@ -230,6 +230,33 @@ class action_plugin_edittable_editor extends DokuWiki_Action_Plugin
         $table = rtrim($table, "\n");
 
         return $table;
+    }
+
+    /**
+     * Return width of string
+     *
+     * @param string $str
+     * @return int
+     */
+    public function strWidth($str)
+    {
+        static $callable;
+
+        if (isset($callable)) {
+            return $callable($str);
+        } else {
+            if (UTF8_MBSTRING) {
+                // count fullwidth characters as 2, halfwidth characters as 1
+                $callable = 'mb_strwidth';
+            } elseif (method_exists(Utf8\PhpString::class, 'strlen')) {
+                // count any characters as 1
+                $callable = [Utf8\PhpString::class, 'strlen'];
+            } else {
+                // fallback deprecated utf8_strlen since 2019-06-09
+                $callable = 'utf8_strlen';
+            }
+            return $this->strWidth($str);
+        }
     }
 
 }

--- a/action/editor.php
+++ b/action/editor.php
@@ -122,14 +122,14 @@ class action_plugin_edittable_editor extends DokuWiki_Action_Plugin {
      *
      * @author Andreas Gohr <gohr@cosmocode,de>
      */
-    public function handle_table_post($event) {
+    public function handle_table_post(Doku_Event $event)
+    {
         global $TEXT;
         global $INPUT;
-        if(!$INPUT->post->has('edittable_data')) return;
+        if (!$INPUT->post->has('edittable_data')) return;
 
-        $json = new JSON(JSON_LOOSE_TYPE);
-        $data = $json->decode($INPUT->post->str('edittable_data'));
-        $meta = $json->decode($INPUT->post->str('edittable_meta'));
+        $data = json_decode($INPUT->post->str('edittable_data'), true);
+        $meta = json_decode($INPUT->post->str('edittable_meta'), true);
 
         $TEXT = $this->build_table($data, $meta);
     }

--- a/action/jsinfo.php
+++ b/action/jsinfo.php
@@ -1,23 +1,23 @@
 <?php
 
-if(!defined('DOKU_INC')) die();
-
 /**
  * handles the data that has to be written into jsinfo
  *
  * like displaying the editor and adding custom edit buttons
  */
-class action_plugin_edittable_jsinfo extends DokuWiki_Action_Plugin {
-
+class action_plugin_edittable_jsinfo extends DokuWiki_Action_Plugin
+{
     /**
      * Register its handlers with the DokuWiki's event controller
      */
-    function register(Doku_Event_Handler $controller) {
+    public function register(Doku_Event_Handler $controller)
+    {
         // register custom edit buttons
         $controller->register_hook('DOKUWIKI_STARTED', 'BEFORE', $this, 'fill_jsinfo');
     }
 
-    function fill_jsinfo() {
+    public function fill_jsinfo()
+    {
         global $JSINFO;
         $JSINFO['plugins']['edittable']['default columnwidth'] = $this->getConf('default colwidth');
     }

--- a/action/newtable.php
+++ b/action/newtable.php
@@ -5,18 +5,16 @@
  * @author     Adrian Lang <lang@cosmocode.de>
  */
 
-if(!defined('DOKU_INC')) die();
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC.'lib/plugins/');
-
 /**
  * Handles the inserting of a new table in a running edit session
  */
-class action_plugin_edittable_newtable extends DokuWiki_Action_Plugin {
-
+class action_plugin_edittable_newtable extends DokuWiki_Action_Plugin
+{
     /**
      * Register its handlers with the DokuWiki's event controller
      */
-    function register(Doku_Event_Handler $controller) {
+    function register(Doku_Event_Handler $controller)
+    {
         $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'toolbar');
 
         //$controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this, 'handle_newtable');
@@ -28,7 +26,8 @@ class action_plugin_edittable_newtable extends DokuWiki_Action_Plugin {
      *
      * @param Doku_Event $event
      */
-    function toolbar($event) {
+    public function toolbar(Doku_Event $event)
+    {
         $event->data[] = array(
             'title' => $this->getLang('add_table'),
             'type'  => 'NewTable',
@@ -42,11 +41,12 @@ class action_plugin_edittable_newtable extends DokuWiki_Action_Plugin {
      *
      * @param Doku_Event $event
      */
-    function handle_newtable($event) {
+    public function handle_newtable(Doku_Event $event)
+    {
         global $INPUT;
         global $TEXT;
 
-        if(!$INPUT->post->has('edittable__new')) return;
+        if (!$INPUT->post->has('edittable__new')) return;
 
         /*
          * $fields['pre']  has all data before the selection when the "Insert table" button was clicked
@@ -64,7 +64,7 @@ class action_plugin_edittable_newtable extends DokuWiki_Action_Plugin {
 
 
         $event->data = act_clean($event->data);
-        switch($event->data){
+        switch ($event->data) {
             case 'preview':
                 // preview view of a table edit
                 $INPUT->post->set('target', 'table');
@@ -73,7 +73,7 @@ class action_plugin_edittable_newtable extends DokuWiki_Action_Plugin {
                 // edit view of a table (first edit)
                 $INPUT->post->set('target', 'table');
                 $TEXT = "^  ^  ^\n";
-                foreach(explode("\n", $fields['text']) as $line) {
+                foreach (explode("\n", $fields['text']) as $line) {
                     $TEXT .= "| $line |  |\n";
                 }
                 break;

--- a/action/preprocess.php
+++ b/action/preprocess.php
@@ -5,9 +5,6 @@
  * @author Andreas Gohr <gohr@cosmocode.de>
  */
 
-if(!defined('DOKU_INC')) die();
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC.'lib/plugins/');
-
 /**
  * just intercepts ACTION_ACT_PREPROCESS and emits two new events
  *
@@ -15,12 +12,13 @@ if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC.'lib/plugins/');
  * That's currently not possible to guarantee, so we catch the event only once and emit two of our own
  * in the right order. Once DokuWiki supports a sort we can skip this.
  */
-class action_plugin_edittable_preprocess extends DokuWiki_Action_Plugin {
-
+class action_plugin_edittable_preprocess extends DokuWiki_Action_Plugin
+{
     /**
      * Register its handlers with the DokuWiki's event controller
      */
-    function register(Doku_Event_Handler $controller) {
+    public function register(Doku_Event_Handler $controller)
+    {
         // register preprocessing for accepting editor data
         $controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this, 'handle_preprocess');
     }
@@ -30,7 +28,8 @@ class action_plugin_edittable_preprocess extends DokuWiki_Action_Plugin {
      *
      * @param Doku_Event $event
      */
-    public function handle_preprocess(Doku_Event $event){
+    public function handle_preprocess(Doku_Event $event)
+    {
         trigger_event('PLUGIN_EDITTABLE_PREPROCESS_EDITOR', $event->data);
         trigger_event('PLUGIN_EDITTABLE_PREPROCESS_NEWTABLE', $event->data);
     }

--- a/action/sectionjump.php
+++ b/action/sectionjump.php
@@ -5,15 +5,16 @@
  * @author     Adrian Lang <lang@cosmocode.de>
  */
 
-if(!defined('DOKU_INC')) die();
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC.'lib/plugins/');
-
-class action_plugin_edittable_sectionjump extends DokuWiki_Action_Plugin {
-
+/**
+ * redirect to the section containg the table
+ */
+class action_plugin_edittable_sectionjump extends DokuWiki_Action_Plugin
+{
     /**
      * Register its handlers with the DokuWiki's event controller
      */
-    function register(Doku_Event_Handler $controller) {
+    function register(Doku_Event_Handler $controller)
+    {
         $controller->register_hook('ACTION_SHOW_REDIRECT', 'BEFORE', $this, 'jump_to_section');
     }
 
@@ -22,12 +23,13 @@ class action_plugin_edittable_sectionjump extends DokuWiki_Action_Plugin {
      *
      * @param Doku_Event $event
      */
-    function jump_to_section($event) {
+    function jump_to_section($event)
+    {
         global $INPUT;
-        if(!$INPUT->has('edittable_data')) return;
+        if (!$INPUT->has('edittable_data')) return;
 
         global $PRE;
-        if(preg_match_all('/^\s*={2,}([^=\n]+)/m', $PRE, $match, PREG_SET_ORDER)) {
+        if (preg_match_all('/^\s*={2,}([^=\n]+)/m', $PRE, $match, PREG_SET_ORDER)) {
             $check                   = false; //Byref
             $match                   = array_pop($match);
             $event->data['fragment'] = sectionID($match[1], $check);

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -2,6 +2,6 @@ base    edittable
 author  Andreas Gohr
 email   dokuwiki@cosmocode.de
 date    2020-08-12
-name    edittable plugin
+name    EditTable plugin
 desc    Provide a custom editor for tables
-url     http://www.dokuwiki.org/plugin:edittable
+url     https://www.dokuwiki.org/plugin:edittable

--- a/renderer/json.php
+++ b/renderer/json.php
@@ -35,8 +35,7 @@ class renderer_plugin_edittable_json extends renderer_plugin_edittable_inverse {
      * @return array
      */
     public function getDataJSON() {
-        $json = new JSON();
-        return $json->encode($this->tdata);
+        return json_encode($this->tdata);
     }
 
     /**
@@ -45,8 +44,7 @@ class renderer_plugin_edittable_json extends renderer_plugin_edittable_inverse {
      * @return array
      */
     public function getMetaJSON() {
-        $json = new JSON();
-        return $json->encode($this->tmeta);
+        return json_encode($this->tmeta);
     }
 
     // renderer functions below


### PR DESCRIPTION
This PR will make the EditTable plugin compatible with DokuWiki snapshot 2020-10-13 or later that [#3198](https://github.com/splitbrain/dokuwiki/pull/3198) merged. The edit form has now build using new **dokuwiki\Form\Form** class instead of deprecated **Doku_Form**.  We need new event **EDIT_FORM_ADDTEXTAREA** handler to modify the edit form.

This PR will also fix issues of deprecated `JSON()->decode()` methods and `utf8_strlen()`. 
