### PR TITLE
colspanned columns should inherit tag

### DIFF
--- a/renderer/json.php
+++ b/renderer/json.php
@@ -127,6 +127,7 @@ class renderer_plugin_edittable_json extends renderer_plugin_edittable_inverse {
 
             for($c = 1; $c < $colspan; $c++) {
                 // hide colspanned cell in same row
+                $this->tmeta[$row][$col + $c]['tag'] = $this->tmeta[$row][$col]['tag'];
                 $this->tmeta[$row][$col + $c]['hide'] = true;
                 $this->tmeta[$row][$col + $c]['rowspan'] = 1;
                 $this->tmeta[$row][$col + $c]['colspan'] = 1;


### PR DESCRIPTION
Colspanned columns need to inherit the tag of the original column. Otherwise, in a header row, this leaves you with a bunch of `th` tags separated by `tds` tags (since the default is to treat an empty tag as `td` per https://github.com/cosmocode/edittable/blob/09298eaff7a6ebcb9892511587fac055380c5653/action/editor.php#L222)

When the array is parsed by build_table, this means the table is actually malformed per DokuWiki syntax and what should be a `^` ends up being a `|`; this later generates bad or unexpected HTML - `th` elements end up in `tbody` instead of `thead`.