### PR TITLE
Fixed issue with reversed scrolling direction when mouse wheel is used.

### DIFF
--- a/lib/handsontable.full.js
+++ b/lib/handsontable.full.js
@@ -48545,13 +48545,15 @@ function TableView(instance) {
 
   if (!(0, _browser.isChrome)() && !(0, _browser.isSafari)()) {
     this.eventManager.addEventListener(instance.rootElement, 'wheel', function (event) {
-      event.preventDefault();
-
       var lineHeight = parseInt((0, _element.getComputedStyle)(document.body)['font-size'], 10);
       var holder = that.wt.wtOverlays.scrollableElement;
 
-      var deltaY = event.wheelDeltaY || event.deltaY;
-      var deltaX = event.wheelDeltaX || event.deltaX;
+      if (holder !== window) {
+        event.preventDefault();
+      }
+
+      let deltaY = (-1) * event.wheelDeltaY || event.deltaY;
+      let deltaX = (-1) * event.wheelDeltaX || event.deltaX;
 
       switch (event.deltaMode) {
         case 0:


### PR DESCRIPTION
Fixed the issue (https://github.com/cosmocode/edittable/issues/208) with a reversed (up <-> down) scrolling direction when the mouse wheel is used. This is done by backporting the change:
  https://github.com/handsontable/handsontable/commit/378ab1f9c56d421ae8d541948fa6db99a9880bcb
in the bundled "handsontable" JavaScript library from version 0.38.0 to version 0.34.1 which is bundled with the edittable plugin.